### PR TITLE
Updated color of ion-icon in ion-chip, ion-chip outline and ion-item lines in dark mode(#238p38r)

### DIFF
--- a/changelogs/unreleased/--238p38r.yml
+++ b/changelogs/unreleased/--238p38r.yml
@@ -1,0 +1,7 @@
+---
+title: Updated color of ion-icon in ion-chip, ion-chip outline and ion-item lines
+  in dark mode
+ticket_id: "##238p38r"
+merge_request: 23
+author: azkyakhan
+type: changed

--- a/src/theme/variables.css
+++ b/src/theme/variables.css
@@ -326,3 +326,17 @@ hr {
     display: unset;
   }  
 }
+
+@media (prefers-color-scheme: dark) {
+  ion-chip > ion-icon {
+    color: var(--ion-color-dark);
+  }
+
+  .chip-outline {
+    border-color: var(--ion-color-dark);
+  }
+
+  ion-item {
+    --border-color: var(--ion-color-medium)
+  }
+}


### PR DESCRIPTION
![threshold-management](https://user-images.githubusercontent.com/82817616/157663410-eba5a261-5c7e-477b-abdc-b1972923582d.png)
