### PR TITLE
Improved: code to remove 'None' as shop option from settings page (#29wgty7).

### DIFF
--- a/src/store/modules/user/actions.ts
+++ b/src/store/modules/user/actions.ts
@@ -68,11 +68,10 @@ const actions: ActionTree<UserState, RootState> = {
         emitter.emit('timeZoneDifferent', { profileTimeZone: resp.data.userTimeZone, localTimeZone});
       }
 
-      await dispatch('getEComStores', payload).then((stores: any) => { resp.data.stores = [{
-        productStoreId: "",
-        storeName: "None"
-        }, ...(stores ? stores : [])]
-      })
+      await dispatch('getEComStores', payload).then((stores: any) => {
+        resp.data.stores = stores ? stores : [];
+        commit(types.USER_CURRENT_ECOM_STORE_UPDATED, stores ? stores[0] : {});
+      });
 
       commit(types.USER_INFO_UPDATED, resp.data);
     }

--- a/src/store/modules/user/index.ts
+++ b/src/store/modules/user/index.ts
@@ -12,10 +12,7 @@ const userModule: Module<UserState, RootState> = {
       current: null,
       currentFacility: {},
       instanceUrl: '',
-      currentEComStore: {
-        productStoreId: "",
-        storeName: "None"
-      },
+      currentEComStore: {},
     },
     getters,
     actions,

--- a/src/store/modules/user/mutations.ts
+++ b/src/store/modules/user/mutations.ts
@@ -10,10 +10,7 @@ const mutations: MutationTree <UserState> = {
       state.token = ''
       state.current = null
       state.currentFacility = {}
-      state.currentEComStore = {
-        productStoreId: "",
-        storeName: "None"
-      }
+      state.currentEComStore = {}
     },
     [types.USER_INFO_UPDATED] (state, payload) {
         state.current = payload


### PR DESCRIPTION
### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->

Closes #

### Short Description and Why It's Useful
<!-- Describe in a few words what is this Pull Request changing and why it's useful -->
Worked on improving the code to remove the None option from shop which is set by default by us when a user is trying to log in and used first store/shop selected by default when a user is logging in initially.

### Screenshots of Visual Changes before/after (If There Are Any)
<!-- If you made any changes in the UI layer, please provide before/after screenshots -->

**Screenshots:**
- Settings page:
![image](https://user-images.githubusercontent.com/52008359/167100768-82663a87-ffee-4a5b-b287-cb7afb2aad31.png)


**IMPORTANT NOTICE** - Remember to add changelog entry


### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->