### PR TITLE
Fixed: code to handle the case when job history modal isn't updating (#2adm63m).

### DIFF
--- a/src/components/JobHistoryModal.vue
+++ b/src/components/JobHistoryModal.vue
@@ -92,11 +92,6 @@ export default defineComponent({
     async fetchJobHistory() {
       let resp;
 
-      if(!this.currentJob?.systemJobEnumId) {
-        this.jobHistory = [];
-        return
-      }
-
       try {
         resp = await JobService.fetchJobInformation({
           "inputFields": {

--- a/src/components/JobHistoryModal.vue
+++ b/src/components/JobHistoryModal.vue
@@ -92,6 +92,11 @@ export default defineComponent({
     async fetchJobHistory() {
       let resp;
 
+      if(!this.currentJob?.systemJobEnumId) {
+        this.jobHistory = [];
+        return
+      }
+
       try {
         resp = await JobService.fetchJobInformation({
           "inputFields": {

--- a/src/views/ThresholdUpdates.vue
+++ b/src/views/ThresholdUpdates.vue
@@ -131,6 +131,7 @@
               </ion-item>
 
               <div class="actions">
+                <div></div>
                 <div>
                   <ion-button fill="clear" color="medium" slot="end" @click.stop="copyJobInformation(job)">
                     <ion-icon slot="icon-only" :icon="copyOutline" />
@@ -199,6 +200,7 @@
             </ion-item>
 
             <div class="actions">
+              <div></div>
               <div>
                 <ion-button fill="clear" color="medium" slot="end" @click.stop="copyJobInformation(job)">
                   <ion-icon slot="icon-only" :icon="copyOutline" />

--- a/src/views/ThresholdUpdates.vue
+++ b/src/views/ThresholdUpdates.vue
@@ -72,7 +72,7 @@
                   <ion-button fill="clear" color="medium" slot="end" @click.stop="copyJobInformation(job)">
                     <ion-icon slot="icon-only" :icon="copyOutline" />
                   </ion-button>
-                  <ion-button fill="clear" color="medium" slot="end" @click.stop="viewJobHistory()">
+                  <ion-button fill="clear" color="medium" slot="end" @click.stop="viewJobHistory(job)">
                     <ion-icon slot="icon-only" :icon="timeOutline" />
                   </ion-button>
                 </div>
@@ -129,6 +129,17 @@
                 <ion-icon slot="start" :icon="codeWorkingOutline" />
                 <ion-label class="ion-text-wrap">{{ job.serviceName }}</ion-label>
               </ion-item>
+
+              <div class="actions">
+                <div>
+                  <ion-button fill="clear" color="medium" slot="end" @click.stop="copyJobInformation(job)">
+                    <ion-icon slot="icon-only" :icon="copyOutline" />
+                  </ion-button>
+                  <ion-button fill="clear" color="medium" slot="end" @click.stop="viewJobHistory(job)">
+                    <ion-icon slot="icon-only" :icon="timeOutline" />
+                  </ion-button>
+                </div>
+              </div>
             </ion-card>
 
             <ion-refresher slot="fixed" @ionRefresh="refreshJobs($event)">
@@ -187,6 +198,16 @@
               <ion-label class="ion-text-wrap">{{ job.serviceName }}</ion-label>
             </ion-item>
 
+            <div class="actions">
+              <div>
+                <ion-button fill="clear" color="medium" slot="end" @click.stop="copyJobInformation(job)">
+                  <ion-icon slot="icon-only" :icon="copyOutline" />
+                </ion-button>
+                <ion-button fill="clear" color="medium" slot="end" @click.stop="viewJobHistory(job)">
+                  <ion-icon slot="icon-only" :icon="timeOutline" />
+                </ion-button>
+              </div>
+            </div>
           </ion-card>
 
           <ion-refresher slot="fixed" @ionRefresh="refreshJobs($event)">


### PR DESCRIPTION
### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->

Closes #73 

### Short Description and Why It's Useful
<!-- Describe in a few words what is this Pull Request changing and why it's useful -->
:- Improved code to add support to show history on running and history segments.
:- Implemented functionality to add support to update job history modal.
:- Improved code to add an empty div to handle the case when we have a missing slot of flex in the actions section.

### Screenshots of Visual Changes before/after (If There Are Any)
<!-- If you made any changes in the UI layer, please provide before/after screenshots -->
![image](https://user-images.githubusercontent.com/52008359/167839694-9bc8fc65-2e2a-4f29-89dc-63db31d90221.png)

**IMPORTANT NOTICE** - Remember to add changelog entry


### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [ ] I read and followed [contribution rules](https://github.com/hotwax/job-manager#contribution-guideline)