### PR TITLE
Fixed: issue of temp expr not being set when scheduling a new job(#2dmgzqb)

### DIFF
--- a/src/components/SaveThresholdModal.vue
+++ b/src/components/SaveThresholdModal.vue
@@ -185,7 +185,7 @@ export default defineComponent({
         'jobFields': {
           'productStoreId': productStoreId,
           'systemJobEnumId': job.systemJobEnumId,
-          'tempExprId': 'EVERYDAY',  // Need to remove this as we are passing frequency in SERVICE_TEMP_EXPR, Kept it for now for backward compatibility
+          'tempExprId': 'EVERYDAY',  // Need to remove this as we are passing frequency in SERVICE_TEMP_EXPR, currently kept it for backward compatibility
           'maxRecurrenceCount': '-1',
           'parentJobId': job.parentJobId,
           'runAsUser': 'system', // default system, but empty in run now

--- a/src/components/SaveThresholdModal.vue
+++ b/src/components/SaveThresholdModal.vue
@@ -181,10 +181,11 @@ export default defineComponent({
         'JOB_NAME': this.jobName ? this.jobName : this.userProfile.partyName,
         'SERVICE_NAME': job.serviceName,
         'SERVICE_COUNT': '0',
+        'SERVICE_TEMP_EXPR': 'EVERYDAY',
         'jobFields': {
           'productStoreId': productStoreId,
           'systemJobEnumId': job.systemJobEnumId,
-          'tempExprId': 'EVERYDAY',
+          'tempExprId': 'EVERYDAY',  // Need to remove this as we are passing frequency in SERVICE_TEMP_EXPR, Kept it for now for backward compatibility
           'maxRecurrenceCount': '-1',
           'parentJobId': job.parentJobId,
           'runAsUser': 'system', // default system, but empty in run now

--- a/src/store/modules/job/actions.ts
+++ b/src/store/modules/job/actions.ts
@@ -312,7 +312,7 @@ const actions: ActionTree<JobState, RootState> = {
       'jobFields': {
         'productStoreId': this.state.user.currentEComStore.productStoreId,
         'systemJobEnumId': job.systemJobEnumId,
-        'tempExprId': job.jobStatus, // Need to remove this as we are passing frequency in SERVICE_TEMP_EXPR, Kept it for now for backward compatibility
+        'tempExprId': job.jobStatus, // Need to remove this as we are passing frequency in SERVICE_TEMP_EXPR, currently kept it for backward compatibility
         'maxRecurrenceCount': '-1',
         'parentJobId': job.parentJobId,
         'runAsUser': 'system', // default system, but empty in run now

--- a/src/store/modules/job/actions.ts
+++ b/src/store/modules/job/actions.ts
@@ -308,10 +308,11 @@ const actions: ActionTree<JobState, RootState> = {
       'JOB_NAME': job.jobName,
       'SERVICE_NAME': job.serviceName,
       'SERVICE_COUNT': '0',
+      'SERVICE_TEMP_EXPR': job.jobStatus,
       'jobFields': {
         'productStoreId': this.state.user.currentEComStore.productStoreId,
         'systemJobEnumId': job.systemJobEnumId,
-        'tempExprId': job.jobStatus,
+        'tempExprId': job.jobStatus, // Need to remove this as we are passing frequency in SERVICE_TEMP_EXPR, Kept it for now for backward compatibility
         'maxRecurrenceCount': '-1',
         'parentJobId': job.parentJobId,
         'runAsUser': 'system', // default system, but empty in run now


### PR DESCRIPTION
### Related Issues
 <!--  Put related issue number which this PR is closing. For example #123 -->
 When scheduling a job the temporal expression for the job is not being set

 Closes #

 ### Short Description and Why It's Useful
 <!-- Describe in a few words what is this Pull Request changing and why it's useful -->
Passed the field SERVICE_TEMP_EXPR when scheduling the job as this field overrides the already passed field tempExprId


 ### Screenshots of Visual Changes before/after (If There Are Any)
 <!-- If you made any changes in the UI layer, please provide before/after screenshots -->


 **IMPORTANT NOTICE** - Remember to add changelog entry


 ### Contribution and Currently Important Rules Acceptance
 <!-- Please get familiar with following info -->

 - [x] I read and followed [contribution rules](https://github.com/hotwax/threshold-management#contribution-guideline)