### PR TITLE
Fixed: Error: Something went wrong on successful cancelling of  job (#2ftb67b)

### DIFF
--- a/src/store/modules/job/actions.ts
+++ b/src/store/modules/job/actions.ts
@@ -386,7 +386,7 @@ const actions: ActionTree<JobState, RootState> = {
     return resp;
   },
 
-  async cancelJob({ dispatch, state }, job) {
+  async cancelJob({ dispatch, state, commit }, job) {
     let resp;
 
     try {
@@ -399,8 +399,8 @@ const actions: ActionTree<JobState, RootState> = {
       });
       if (resp.status == 200 && !hasError(resp)) {
         showToast(translate('Service updated successfully'))
-        state.cached[job.systemJobEnumId].statusId = 'SERVICE_DRAFT'
-        state.cached[job.systemJobEnumId].status = 'SERVICE_DRAFT'
+        // deleting the enum from cached job as we will not store the job with cancelled status
+        delete state.cached[job?.systemJobEnumId]
         dispatch('fetchJobs', {
           inputFields: {
             'systemJobEnumId': job.systemJobEnumId,

--- a/src/store/modules/job/actions.ts
+++ b/src/store/modules/job/actions.ts
@@ -386,7 +386,7 @@ const actions: ActionTree<JobState, RootState> = {
     return resp;
   },
 
-  async cancelJob({ dispatch, state, commit }, job) {
+  async cancelJob({ dispatch, state }, job) {
     let resp;
 
     try {


### PR DESCRIPTION
Initially we were setting the status of Job from cached without checking if it exist
Deleted the job from cached instead of updating the status, fetchJobs action is already used to update cache with available jobs

### Related Issues
 <!--  Put related issue number which this PR is closing. For example #123 -->

 Closes https://app.clickup.com/t/2ftb67b

 ### Short Description and Why It's Useful
 <!-- Describe in a few words what is this Pull Request changing and why it's useful -->


 ### Screenshots of Visual Changes before/after (If There Are Any)
 <!-- If you made any changes in the UI layer, please provide before/after screenshots -->


 **IMPORTANT NOTICE** - Remember to add changelog entry


 ### Contribution and Currently Important Rules Acceptance
 <!-- Please get familiar with following info -->

 - [x] I read and followed [contribution rules](https://github.com/hotwax/threshold-management#contribution-guideline)