### PR TITLE
fixed: ShopifyConfig id is undefined when making api call while scheduling the job(#2kbpaux)

### DIFF
--- a/src/components/SaveThresholdModal.vue
+++ b/src/components/SaveThresholdModal.vue
@@ -163,8 +163,8 @@ export default defineComponent({
       }
 
       if(!shopifyConfigId) {
-        const resp = await this.store.dispatch('util/getShopifyConfig', productStoreId)
-        shopifyConfigId = resp.shopifyConfigId
+        const shopifyConfigResp = await this.store.dispatch('util/getShopifyConfig', productStoreId)
+        shopifyConfigId = shopifyConfigResp.shopifyConfigId
       }
 
       if (!facilityId) {

--- a/src/components/SaveThresholdModal.vue
+++ b/src/components/SaveThresholdModal.vue
@@ -164,7 +164,7 @@ export default defineComponent({
 
       if(!shopifyConfigId) {
         const resp = await this.store.dispatch('util/getShopifyConfig', productStoreId)
-        shopifyConfigId = resp[productStoreId]
+        shopifyConfigId = resp.shopifyConfigId
       }
 
       if (!facilityId) {

--- a/src/components/SaveThresholdModal.vue
+++ b/src/components/SaveThresholdModal.vue
@@ -163,8 +163,8 @@ export default defineComponent({
       }
 
       if(!shopifyConfigId) {
-        const shopifyConfigResp = await this.store.dispatch('util/getShopifyConfig', productStoreId)
-        shopifyConfigId = shopifyConfigResp.shopifyConfigId
+        const shopifyConfig = await this.store.dispatch('util/getShopifyConfig', productStoreId)
+        shopifyConfigId = shopifyConfig.shopifyConfigId
       }
 
       if (!facilityId) {


### PR DESCRIPTION
### Related Issues
 <!--  Put related issue number which this PR is closing. For example #123 -->

 Closes #

 ### Short Description and Why It's Useful
 <!-- Describe in a few words what is this Pull Request changing and why it's useful -->
we were using the productStoreId to fetch the configId, which is always undefined. 
Instead used shopifyConfig.shopifyConfigId to get shopify config id

 ### Screenshots of Visual Changes before/after (If There Are Any)
 <!-- If you made any changes in the UI layer, please provide before/after screenshots -->


 **IMPORTANT NOTICE** - Remember to add changelog entry


 ### Contribution and Currently Important Rules Acceptance
 <!-- Please get familiar with following info -->

 - [ ] I read and followed [contribution rules](https://github.com/hotwax/threshold-management#contribution-guideline)