### PR TITLE
Fixed: issue of facilitiesByProductStore and ShopifyConfig data not cleared on logout(#85zrn9yfn)

### DIFF
--- a/src/store/modules/user/actions.ts
+++ b/src/store/modules/user/actions.ts
@@ -120,6 +120,8 @@ const actions: ActionTree<UserState, RootState> = {
     commit(types.USER_END_SESSION)
     this.dispatch('product/clearAllFilters')
     this.dispatch('product/clearProductList');
+    this.dispatch('util/clearFacilitiesByProductStore')
+    this.dispatch('util/clearShopifyConfig')
     resetPermissions();
     resetConfig();
   },

--- a/src/store/modules/util/actions.ts
+++ b/src/store/modules/util/actions.ts
@@ -45,8 +45,11 @@ const actions: ActionTree<UtilState, RootState> = {
     })
 
     if (resp.status === 200 && !hasError(resp) && resp?.data?.docs?.length > 0) {
-      commit(types.UTIL_SHOPIFY_CONFIG_UPDATED, resp.data.docs?.length > 0 ? resp.data.docs[0] : {});
-      return resp.data.docs[0];
+      const shopifyConfig = resp.data.docs[0]
+      commit(types.UTIL_SHOPIFY_CONFIG_UPDATED, resp.data.docs?.length > 0 ? {
+        [shopifyConfig.productStoreId]: shopifyConfig.shopifyConfigId
+      } : {});
+      return shopifyConfig;
     }
     return {};
   },

--- a/src/store/modules/util/actions.ts
+++ b/src/store/modules/util/actions.ts
@@ -76,6 +76,14 @@ const actions: ActionTree<UtilState, RootState> = {
     }
     return {};
   },
+
+  async clearFacilitiesByProductStore({ commit }) {
+    commit(types.UTIL_PRODUCT_STORE_FACILITY_UPDATED, {})
+  },
+
+  async clearShopifyConfig({ commit }) {
+    commit(types.UTIL_SHOPIFY_CONFIG_UPDATED, {})
+  }
 }
 
 export default actions;

--- a/src/store/modules/util/mutations.ts
+++ b/src/store/modules/util/mutations.ts
@@ -9,10 +9,10 @@ const mutations: MutationTree <UtilState> = {
     })
   },
   [types.UTIL_SHOPIFY_CONFIG_UPDATED] (state, payload) {
-    state.shopifyConfig[payload.productStoreId] = payload.shopifyConfigId;
+    state.shopifyConfig = payload;
   },
   [types.UTIL_PRODUCT_STORE_FACILITY_UPDATED] (state, payload) {
-    state.facilitiesByProductStore[payload.productStoreId] = payload
+    state.facilitiesByProductStore = payload
   }
 }
 export default mutations;


### PR DESCRIPTION
### Related Issues
 <!--  Put related issue number which this PR is closing. For example #123 -->

 Closes #163 

 ### Short Description and Why It's Useful
 <!-- Describe in a few words what is this Pull Request changing and why it's useful -->
Current the information related to facilties and product store are being cleared on logout, resulting in some conflict in values. So, updated the mutations and defined actions to clear data for both the state variables on logout.

 ### Screenshots of Visual Changes before/after (If There Are Any)
 <!-- If you made any changes in the UI layer, please provide before/after screenshots -->


 **IMPORTANT NOTICE** - Remember to add changelog entry


 ### Contribution and Currently Important Rules Acceptance
 <!-- Please get familiar with following info -->

 - [x] I read and followed [contribution rules](https://github.com/hotwax/threshold-management#contribution-guideline)