### PR TITLE
Fixed: infinite scroll issue when used with searchbar(dxp-289) 

### DIFF
--- a/src/components/ProductFilterModal.vue
+++ b/src/components/ProductFilterModal.vue
@@ -29,7 +29,7 @@
         <ion-icon :icon="checkmarkOutline" />
       </ion-fab-button>
     </ion-fab>
-    <ion-infinite-scroll @ionInfinite="loadMoreTags($event)" threshold="100px" :disabled="!isScrollable">
+    <ion-infinite-scroll @ionInfinite="loadMoreTags($event)" threshold="100px" :disabled="!isScrollable" :key="queryString">
       <ion-infinite-scroll-content loading-spinner="crescent" :loading-text="$t('Loading')"/>
     </ion-infinite-scroll>
   </ion-content>

--- a/src/components/ProductFilterModal.vue
+++ b/src/components/ProductFilterModal.vue
@@ -29,7 +29,7 @@
         <ion-icon :icon="checkmarkOutline" />
       </ion-fab-button>
     </ion-fab>
-    <ion-infinite-scroll @ionInfinite="loadMoreTags($event)" threshold="100px" v-show="isScrollingEnabled && isScrollable" ref="infiniteScrollRef">
+    <ion-infinite-scroll @ionInfinite="loadMoreTags($event)" threshold="100px" v-show="isScrollable" ref="infiniteScrollRef">
       <ion-infinite-scroll-content loading-spinner="crescent" :loading-text="$t('Loading')"/>
     </ion-infinite-scroll>
   </ion-content>
@@ -150,6 +150,10 @@ export default defineComponent({
       }
     },
     async loadMoreTags(event: any){
+       // Added this check here as if added on infinite-scroll component the Loading content does not gets displayed
+       if(!(this.isScrollingEnabled && this.isScrollable)) {
+        await event.target.complete();
+      }
       this.getTags(
         undefined,
         Math.ceil(this.facetOptions.length / process.env.VUE_APP_VIEW_SIZE).toString() 

--- a/src/components/ProductFilterModal.vue
+++ b/src/components/ProductFilterModal.vue
@@ -13,7 +13,7 @@
     </ion-toolbar>
   </ion-header>
 
-  <ion-content>
+  <ion-content ref="contentRef" :scroll-events="true" @ionScroll="enableScrolling()">
     <ion-searchbar :placeholder="$t(`Search ${label}`)" v-model="queryString" @keyup.enter="queryString = $event.target.value; search($event)"/>
 
     <ion-list>
@@ -29,7 +29,7 @@
         <ion-icon :icon="checkmarkOutline" />
       </ion-fab-button>
     </ion-fab>
-    <ion-infinite-scroll @ionInfinite="loadMoreTags($event)" threshold="100px" :disabled="!isScrollable" :key="queryString">
+    <ion-infinite-scroll @ionInfinite="loadMoreTags($event)" threshold="100px" v-show="isScrollingEnabled && isScrollable" ref="infiniteScrollRef">
       <ion-infinite-scroll-content loading-spinner="crescent" :loading-text="$t('Loading')"/>
     </ion-infinite-scroll>
   </ion-content>
@@ -88,7 +88,8 @@ export default defineComponent({
       facetOptions: [] as any,
       isFilterChanged: false,
       isScrollable: true,
-      selectedValues: [] as Array<string>
+      selectedValues: [] as Array<string>,
+      isScrollingEnabled: false
     }
   },
   computed: {
@@ -99,6 +100,9 @@ export default defineComponent({
   props: ["label", "facetToSelect", "searchfield", 'type'],
   mounted() {
     this.selectedValues = JSON.parse(JSON.stringify(this.appliedFilters[this.type][this.searchfield])).list;
+  },
+  async ionViewWillEnter() {
+    this.isScrollingEnabled = false;
   },
   methods: {
     closeModal() {
@@ -134,13 +138,24 @@ export default defineComponent({
         this.isScrollable = false;
       }
     },
+    enableScrolling() {
+      const parentElement = (this as any).$refs.contentRef.$el
+      const scrollEl = parentElement.shadowRoot.querySelector("main[part='scroll']")
+      let scrollHeight = scrollEl.scrollHeight, infiniteHeight = (this as any).$refs.infiniteScrollRef.$el.offsetHeight, scrollTop = scrollEl.scrollTop, threshold = 100, height = scrollEl.offsetHeight
+      const distanceFromInfinite = scrollHeight - infiniteHeight - scrollTop - threshold - height
+      if(distanceFromInfinite < 0) {
+        this.isScrollingEnabled = false;
+      } else {
+        this.isScrollingEnabled = true;
+      }
+    },
     async loadMoreTags(event: any){
       this.getTags(
         undefined,
         Math.ceil(this.facetOptions.length / process.env.VUE_APP_VIEW_SIZE).toString() 
-      ).then(() => {
-        event.target.complete();
-      })
+      ).then(async () => {
+        await event.target.complete();
+      });
     },
     updateSelectedValues(value: string) {
       this.selectedValues.includes(value) ? this.selectedValues.splice(this.selectedValues.indexOf(value), 1) : this.selectedValues.push(value);

--- a/src/views/SelectProduct.vue
+++ b/src/views/SelectProduct.vue
@@ -133,7 +133,7 @@
             </section>
             <hr />
           </div>
-          <ion-infinite-scroll @ionInfinite="loadMoreProducts($event)" threshold="100px" :disabled="!isScrollable">
+          <ion-infinite-scroll @ionInfinite="loadMoreProducts($event)" threshold="100px" :disabled="!isScrollable" :key="queryString">
             <ion-infinite-scroll-content loading-spinner="crescent" :loading-text="$t('Loading')"/>
           </ion-infinite-scroll>
         </main>

--- a/src/views/SelectProduct.vue
+++ b/src/views/SelectProduct.vue
@@ -133,6 +133,13 @@
             </section>
             <hr />
           </div>
+           <!--
+            When searching for a keyword, and if the user moves to the last item, then the didFire value inside infinite scroll becomes true and thus the infinite scroll does not trigger again on the same page(https://github.com/hotwax/users/issues/84).
+            In ionic v7.6.0, an issue related to infinite scroll has been fixed that when more items can be added to the DOM, but infinite scroll does not fire as the window is not completely filled with the content(https://github.com/ionic-team/ionic-framework/issues/18071).
+            The above fix in ionic 7.6.0 is resulting in the issue of infinite scroll not being called again.
+            To fix this, we have added a key with value as queryString(searched keyword), so that the infinite scroll component can be re-rendered
+            whenever the searched string is changed resulting in the correct behaviour for infinite scroll
+          -->
           <ion-infinite-scroll @ionInfinite="loadMoreProducts($event)" threshold="100px" :disabled="!isScrollable" :key="queryString">
             <ion-infinite-scroll-content loading-spinner="crescent" :loading-text="$t('Loading')"/>
           </ion-infinite-scroll>

--- a/src/views/SelectProduct.vue
+++ b/src/views/SelectProduct.vue
@@ -19,7 +19,7 @@
       </ion-toolbar>
     </ion-header>
 
-    <ion-content>
+    <ion-content ref="contentRef" :scroll-events="true" @ionScroll="enableScrolling()">
       <div class="find">
 
         <aside class="filters desktop-only">
@@ -133,14 +133,16 @@
             </section>
             <hr />
           </div>
-           <!--
+          <!--
             When searching for a keyword, and if the user moves to the last item, then the didFire value inside infinite scroll becomes true and thus the infinite scroll does not trigger again on the same page(https://github.com/hotwax/users/issues/84).
+            Also if we are at the section that has been loaded by infinite-scroll and then move to the details page then the list infinite scroll does not work after coming back to the page
             In ionic v7.6.0, an issue related to infinite scroll has been fixed that when more items can be added to the DOM, but infinite scroll does not fire as the window is not completely filled with the content(https://github.com/ionic-team/ionic-framework/issues/18071).
             The above fix in ionic 7.6.0 is resulting in the issue of infinite scroll not being called again.
-            To fix this, we have added a key with value as queryString(searched keyword), so that the infinite scroll component can be re-rendered
-            whenever the searched string is changed resulting in the correct behaviour for infinite scroll
+            To fix this we have maintained another variable `isScrollingEnabled` to check whether the scrolling can be performed or not.
+            If we do not define an extra variable and just use v-show to check for `isScrollable` then when coming back to the page infinite-scroll is called programatically.
+            We have added an ionScroll event on ionContent to check whether the infiniteScroll can be enabled or not by toggling the value of isScrollingEnabled whenever the height < 0.
           -->
-          <ion-infinite-scroll @ionInfinite="loadMoreProducts($event)" threshold="100px" :disabled="!isScrollable" :key="queryString">
+          <ion-infinite-scroll @ionInfinite="loadMoreProducts($event)" threshold="100px" v-show="isScrollingEnabled && isScrollable" ref="infiniteScrollRef">
             <ion-infinite-scroll-content loading-spinner="crescent" :loading-text="$t('Loading')"/>
           </ion-infinite-scroll>
         </main>
@@ -265,7 +267,8 @@ export default defineComponent({
       isFilterChanged: false,
       isServiceScheduling: false,
       job: {} as any,
-      jobId: "" as any
+      jobId: "" as any,
+      isScrollingEnabled: false
     }
   },
   methods: {
@@ -339,13 +342,24 @@ export default defineComponent({
       const viewIndex = vIndex ? vIndex : 0;
       this.store.dispatch("product/updateQuery", { viewSize, viewIndex, queryString: this.queryString })
     },
+    enableScrolling() {
+      const parentElement = (this as any).$refs.contentRef.$el
+      const scrollEl = parentElement.shadowRoot.querySelector("main[part='scroll']")
+      let scrollHeight = scrollEl.scrollHeight, infiniteHeight = (this as any).$refs.infiniteScrollRef.$el.offsetHeight, scrollTop = scrollEl.scrollTop, threshold = 100, height = scrollEl.offsetHeight
+      const distanceFromInfinite = scrollHeight - infiniteHeight - scrollTop - threshold - height
+      if(distanceFromInfinite < 0) {
+        this.isScrollingEnabled = false;
+      } else {
+        this.isScrollingEnabled = true;
+      }
+    },
     async loadMoreProducts(event: any){
       this.getProducts(
         undefined,
         Math.ceil(this.products.list.length / process.env.VUE_APP_VIEW_SIZE).toString()
-      ).then(() => {
-        event.target.complete();
-      })
+      ).then(async () => {
+        await event.target.complete();
+      });
     },
     async updateThreshold() {
       this.isServiceScheduling = true;
@@ -525,6 +539,7 @@ export default defineComponent({
     emitter.off("productStoreChanged", this.getProducts);
   },
   async ionViewWillEnter(){
+    this.isScrollingEnabled = false;
     this.jobId = this.$route.query.id
     this.isFilterChanged = false;
     if (this.jobId) {

--- a/src/views/SelectProduct.vue
+++ b/src/views/SelectProduct.vue
@@ -142,7 +142,7 @@
             If we do not define an extra variable and just use v-show to check for `isScrollable` then when coming back to the page infinite-scroll is called programatically.
             We have added an ionScroll event on ionContent to check whether the infiniteScroll can be enabled or not by toggling the value of isScrollingEnabled whenever the height < 0.
           -->
-          <ion-infinite-scroll @ionInfinite="loadMoreProducts($event)" threshold="100px" v-show="isScrollingEnabled && isScrollable" ref="infiniteScrollRef">
+          <ion-infinite-scroll @ionInfinite="loadMoreProducts($event)" threshold="100px" v-show="isScrollable" ref="infiniteScrollRef">
             <ion-infinite-scroll-content loading-spinner="crescent" :loading-text="$t('Loading')"/>
           </ion-infinite-scroll>
         </main>
@@ -354,6 +354,10 @@ export default defineComponent({
       }
     },
     async loadMoreProducts(event: any){
+       // Added this check here as if added on infinite-scroll component the Loading content does not gets displayed
+       if(!(this.isScrollingEnabled && this.isScrollable)) {
+        await event.target.complete();
+      }
       this.getProducts(
         undefined,
         Math.ceil(this.products.list.length / process.env.VUE_APP_VIEW_SIZE).toString()


### PR DESCRIPTION
### Related Issues
 <!--  Put related issue number which this PR is closing. For example #123 -->

https://github.com/hotwax/dxp-components/issues/289
 ### Short Description and Why It's Useful
Removed the logic to re-render the infinite-scroll on queryString check that has been added in the previous PR.

Added a variable to check whether the scrolling can be enabled or not whenever users lands on the list page. For this, we have determined the height of the content part scroll and infiniteScroll component and if the height is less than 0 then only enabling the infinite-scroll component

Removed disabled as once the infiniteScroll is disabled it does not gets enabled again, hence removed the disabled property and instead used v-show to enable/disable infinite scroll.



 ### Contribution and Currently Important Rules Acceptance
 <!-- Please get familiar with following info -->

 - [x] I read and followed [contribution rules](https://github.com/hotwax/threshold-management#contribution-guideline)