### PR TITLE
Improved: added empty state text in the channels section in rule creation (#280)

### DIFF
--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -118,6 +118,7 @@
   "New safety stock rule": "New safety stock rule",
   "No Capacity": "No Capacity",
   "No capacity sets the fulfillment capacity to 0, preventing any new orders from being allocated to this facility. To add a fulfillment capacity to this facility, use the custom option.": "No capacity sets the fulfillment capacity to 0, preventing any new orders from being allocated to this facility.{space} To add a fulfillment capacity to this facility, use the custom option.",
+  "No channel found for current product store.": "No channel found for current product store.",
   "No facility found.": "No facility found.",
   "No fulfillment capacity": "No fulfillment capacity",
   "No job found.": "No job found.",

--- a/src/views/CreateShippingRule.vue
+++ b/src/views/CreateShippingRule.vue
@@ -76,15 +76,20 @@
       </section>
 
       <section v-else>
-        <ion-card v-for="facility in configFacilities" :key="facility.facilityId" @click="toggleFacilitySelection(facility.facilityId)" button>
-          <ion-card-header>
-            <div>
-              <ion-card-title>{{ facility.facilityName }}</ion-card-title>
-              <ion-card-subtitle>{{ facility.facilityId }}</ion-card-subtitle>
-            </div>
-            <ion-checkbox :checked="isFacilitySelected(facility.facilityId)" />
-          </ion-card-header>
-        </ion-card>
+        <template v-if="configFacilities.length">
+          <ion-card v-for="facility in configFacilities" :key="facility.facilityId" @click="toggleFacilitySelection(facility.facilityId)" button>
+            <ion-card-header>
+              <div>
+                <ion-card-title>{{ facility.facilityName }}</ion-card-title>
+                <ion-card-subtitle>{{ facility.facilityId }}</ion-card-subtitle>
+              </div>
+              <ion-checkbox :checked="isFacilitySelected(facility.facilityId)" />
+            </ion-card-header>
+          </ion-card>
+        </template>
+        <div v-else class="empty-state">
+          <ion-note>{{ translate("No channel found for current product store.") }}</ion-note>
+        </div>
       </section>
 
       <ProductFilters />
@@ -99,7 +104,7 @@
 </template>
 
 <script setup lang="ts">
-import { IonBackButton, IonButton, IonCard, IonCardContent, IonCardHeader, IonCardSubtitle, IonCardTitle, IonCheckbox, IonChip, IonContent, IonFab, IonFabButton, IonHeader, IonIcon, IonInput, IonItem, IonLabel, IonPage, IonSegment, IonSegmentButton, IonText, IonTitle, IonToggle, IonToolbar, modalController } from '@ionic/vue';
+import { IonBackButton, IonButton, IonCard, IonCardContent, IonCardHeader, IonCardSubtitle, IonCardTitle, IonCheckbox, IonChip, IonContent, IonFab, IonFabButton, IonHeader, IonIcon, IonInput, IonItem, IonLabel, IonNote, IonPage, IonSegment, IonSegmentButton, IonText, IonTitle, IonToggle, IonToolbar, modalController } from '@ionic/vue';
 import { computed, onMounted, ref } from 'vue';
 import { addCircleOutline, closeCircle, saveOutline, storefrontOutline } from 'ionicons/icons'
 import { translate } from "@/i18n";
@@ -300,5 +305,9 @@ ion-card-header {
 
 ion-card-header > ion-checkbox {
   flex-shrink: 0;
+}
+
+.empty-state {
+  align-items: start;
 }
 </style>

--- a/src/views/CreateStorePickupRule.vue
+++ b/src/views/CreateStorePickupRule.vue
@@ -76,15 +76,20 @@
       </section>
 
       <section v-else>
-        <ion-card v-for="facility in configFacilities" :key="facility.facilityId" @click="toggleFacilitySelection(facility.facilityId)" button>
-          <ion-card-header>
-            <div>
-              <ion-card-title>{{ facility.facilityName }}</ion-card-title>
-              <ion-card-subtitle>{{ facility.facilityId }}</ion-card-subtitle>
-            </div>
-            <ion-checkbox :checked="isFacilitySelected(facility.facilityId)" />
-          </ion-card-header>
-        </ion-card>
+        <template v-if="configFacilities.length">
+          <ion-card v-for="facility in configFacilities" :key="facility.facilityId" @click="toggleFacilitySelection(facility.facilityId)" button>
+            <ion-card-header>
+              <div>
+                <ion-card-title>{{ facility.facilityName }}</ion-card-title>
+                <ion-card-subtitle>{{ facility.facilityId }}</ion-card-subtitle>
+              </div>
+              <ion-checkbox :checked="isFacilitySelected(facility.facilityId)" />
+            </ion-card-header>
+          </ion-card>
+        </template>
+        <div v-else class="empty-state">
+          <ion-note>{{ translate("No channel found for current product store.") }}</ion-note>
+        </div>
       </section>
 
       <ProductFilters />
@@ -99,7 +104,7 @@
 </template>
 
 <script setup lang="ts">
-import { IonBackButton, IonButton, IonCard, IonCardContent, IonCardHeader, IonCardSubtitle, IonCardTitle, IonCheckbox, IonChip, IonContent, IonFab, IonFabButton, IonHeader, IonIcon, IonInput, IonItem, IonLabel, IonPage, IonSegment, IonSegmentButton, IonText, IonTitle, IonToggle, IonToolbar, modalController } from '@ionic/vue';
+import { IonBackButton, IonButton, IonCard, IonCardContent, IonCardHeader, IonCardSubtitle, IonCardTitle, IonCheckbox, IonChip, IonContent, IonFab, IonFabButton, IonHeader, IonIcon, IonInput, IonItem, IonLabel, IonNote, IonPage, IonSegment, IonSegmentButton, IonText, IonTitle, IonToggle, IonToolbar, modalController } from '@ionic/vue';
 import { addCircleOutline, closeCircle, saveOutline, storefrontOutline } from 'ionicons/icons'
 import { translate } from "@/i18n";
 import { computed, onMounted, ref } from 'vue';
@@ -301,5 +306,9 @@ ion-card-header {
 
 ion-card-header > ion-checkbox {
   flex-shrink: 0;
+}
+
+.empty-state {
+  align-items: start;
 }
 </style>

--- a/src/views/CreateThresholdRule.vue
+++ b/src/views/CreateThresholdRule.vue
@@ -34,7 +34,7 @@
         <h1>{{ translate("Channels") }} <ion-text color="danger">*</ion-text></h1>
       </div>
 
-      <section> 
+      <section v-if="configFacilities.length">
         <ion-card v-for="facility in configFacilities" :key="facility.facilityId" @click="toggleFacilitySelection(facility.facilityId)" button>
           <ion-card-header>
             <div>
@@ -45,6 +45,9 @@
           </ion-card-header>
         </ion-card>
       </section>
+      <div v-else class="empty-state">
+        <ion-note>{{ translate("No channel found for current product store.") }}</ion-note>
+      </div>
 
       <ProductFilters />
     </ion-content>
@@ -73,6 +76,7 @@ import {
   IonInput,
   IonItem,
   IonPage,
+  IonNote,
   IonText,
   IonTitle,
   IonToolbar
@@ -225,5 +229,9 @@ ion-card-header {
 
 ion-card-header > ion-checkbox {
   flex-shrink: 0;
+}
+
+.empty-state {
+  align-items: start;
 }
 </style>


### PR DESCRIPTION


### Related Issues
 <!--  Put related issue number which this PR is closing. For example #123 -->

 Related Issue #280

 ### Short Description and Why It's Useful
 <!-- Describe in a few words what is this Pull Request changing and why it's useful -->
Added empty state text to be shown if not channels found for a product store in rule creation pages.

 ### Screenshots of Visual Changes before/after (If There Are Any)
 <!-- If you made any changes in the UI layer, please provide before/after screenshots -->
Before 
![Screenshot from 2024-05-01 16-55-15](https://github.com/hotwax/threshold-management/assets/69574321/e0e5672c-833d-4b69-a7e3-0cd3bdf4a9f3)

After
![Screenshot from 2024-05-01 16-54-20](https://github.com/hotwax/threshold-management/assets/69574321/2d1b6e01-915a-4cee-87f6-660d88b96217)



 **IMPORTANT NOTICE** - Remember to add changelog entry


 ### Contribution and Currently Important Rules Acceptance
 <!-- Please get familiar with following info -->

 - [x] I read and followed [contribution rules](https://github.com/hotwax/threshold-management#contribution-guideline)