### PR TITLE
Improved: logic to allow user unselect facility group from the rule conditions which are removed from product store. (#289)

### DIFF
--- a/src/components/RuleItem.vue
+++ b/src/components/RuleItem.vue
@@ -300,7 +300,7 @@ function getRuleConditions(conditionTypeEnumId: string, fieldName?: string, oper
       let facilityGroupIds = condition?.fieldValue.split(",")
         facilityGroupIds = facilityGroupIds.map((id: string) => {
           let group = facilityGroups.value.find((group: any) => group.facilityGroupId === id)
-          return group ? group.facilityGroupName : null
+          return group ? group.facilityGroupName : id
         })
         return facilityGroupIds.join(", ")
     } else {
@@ -313,7 +313,7 @@ function getRuleConditions(conditionTypeEnumId: string, fieldName?: string, oper
       let facilities = condition?.fieldValue.split(",")
       facilities = facilities.map((id: string) => {
         let facility = configFacilities.value.find((facility: any) => facility.facilityId === id)
-        return facility ? facility.facilityName : null
+        return facility ? facility.facilityName : id
       })
       return facilities.join(", ")
     }

--- a/src/components/UpdateFacilityGroupModal.vue
+++ b/src/components/UpdateFacilityGroupModal.vue
@@ -20,11 +20,11 @@
       </ion-segment-button>
     </ion-segment>
 
-    <ion-list v-if="facilityGroups.length">
-      <ion-item v-for="group in facilityGroups" :key="group.facilityGroupId" @click="!isAlreadyApplied(group.facilityGroupId) ? updateSelectedValues(group.facilityGroupId): ''">
-        <ion-label v-if="isAlreadyApplied(group.facilityGroupId)">{{ group.facilityGroupName }}</ion-label>
+    <ion-list v-if="facilityGroupValues.length">
+      <ion-item v-for="group in facilityGroupValues" :key="group.facilityGroupId" @click="!isAlreadyApplied(group.facilityGroupId) ? updateSelectedValues(group.facilityGroupId): ''">
+        <ion-label v-if="isAlreadyApplied(group.facilityGroupId)">{{ group.facilityGroupName ? group.facilityGroupName : group.facilityGroupId }}</ion-label>
         <ion-checkbox v-if="!isAlreadyApplied(group.facilityGroupId)" :checked="isSelected(group.facilityGroupId)">
-          {{ group.facilityGroupName }}
+          {{ group.facilityGroupName ? group.facilityGroupName : group.facilityGroupId }}
         </ion-checkbox>
         <ion-note v-else slot="end" color="danger">{{ selectedSegment === 'included' ? translate("excluded") : translate("included") }}</ion-note>
       </ion-item>
@@ -74,6 +74,7 @@ import emitter from "@/event-bus";
 const selectedSegment = ref("included")
 const includedGroups = ref([]) as any;
 const excludedGroups = ref([]) as any;
+const facilityGroupValues = ref([]) as any;
 
 const props = defineProps(["rule"]);
 const store = useStore();
@@ -87,6 +88,16 @@ onMounted(async () => {
 
   const excludedCondition = props.rule.ruleConditions?.find((condition: any) => condition.conditionTypeEnumId === 'ENTCT_ATP_FAC_GROUPS' && condition.fieldName === 'facilityGroups' && condition.operator === 'not-in')
   if(excludedCondition && excludedCondition.fieldValue) excludedGroups.value = excludedCondition.fieldValue.split(",");
+
+  facilityGroupValues.value = JSON.parse(JSON.stringify(facilityGroups.value));
+
+  includedGroups.value.map((id: any) => {
+    if(!facilityGroups.value.find((group: any) => group.facilityGroupId === id)) facilityGroupValues.value.unshift({ facilityGroupId: id });
+  })
+
+  excludedGroups.value.map((id: any) => {
+    if(!facilityGroups.value.find((group: any) => group.facilityGroupId === id)) facilityGroupValues.value.unshift({ facilityGroupId: id })
+  })
 })
 
 function closeModal() {


### PR DESCRIPTION
### Related Issues
 <!--  Put related issue number which this PR is closing. For example #123 -->

 Related Issue #289

 ### Short Description and Why It's Useful
 <!-- Describe in a few words what is this Pull Request changing and why it's useful -->
- Showed group id in case of group not present in product store.
- Manually added facilityGroupId in select facility group modal to allow user unselect group not present in modal since removed from product store.

 ### Screenshots of Visual Changes before/after (If There Are Any)
 <!-- If you made any changes in the UI layer, please provide before/after screenshots -->
Before
![Screenshot from 2024-05-07 11-06-36](https://github.com/hotwax/threshold-management/assets/69574321/2e73cf2d-94fe-49c5-bd5d-2a4727019e26)

After
![Screenshot from 2024-05-07 11-06-43](https://github.com/hotwax/threshold-management/assets/69574321/9368bf47-55c2-4f62-8fab-c926c2c1c448)


 **IMPORTANT NOTICE** - Remember to add changelog entry


 ### Contribution and Currently Important Rules Acceptance
 <!-- Please get familiar with following info -->

 - [x] I read and followed [contribution rules](https://github.com/hotwax/threshold-management#contribution-guideline)