### PR TITLE
Improved: code to fetch inventory channels based on selected product store and added empty state (#302)

### DIFF
--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -121,6 +121,7 @@
   "No channel found for current product store.": "No channel found for current product store.",
   "No facility found.": "No facility found.",
   "No fulfillment capacity": "No fulfillment capacity",
+  "No inventory channel found.": "No inventory channel found.",
   "No job found.": "No job found.",
   "No jobs have run yet": "No jobs have run yet",
   "No jobs to update": "No jobs to update",

--- a/src/services/ChannelService.ts
+++ b/src/services/ChannelService.ts
@@ -2,7 +2,7 @@ import api from '@/api';
 
 const fetchInventoryChannels = async (payload: any): Promise <any>  => {
   return api({
-    url: 'facilityGroups',
+    url: `productStores/${payload.productStoreId}/facilityGroups`,
     method: "GET",
     params: payload
   });

--- a/src/store/modules/channel/actions.ts
+++ b/src/store/modules/channel/actions.ts
@@ -14,7 +14,7 @@ const actions: ActionTree<ChannelState, RootState> = {
     let inventoryChannels = [] as any
 
     try {
-      resp = await ChannelService.fetchInventoryChannels({ facilityGroupTypeId: "CHANNEL_FAC_GROUP" });
+      resp = await ChannelService.fetchInventoryChannels({ facilityGroupTypeId: "CHANNEL_FAC_GROUP", productStoreId: store.state.user.currentEComStore.productStoreId });
 
       if(!hasError(resp)) {
         inventoryChannels = resp?.data;

--- a/src/views/InventoryChannels.vue
+++ b/src/views/InventoryChannels.vue
@@ -21,53 +21,59 @@
     <ion-content>
       <main>
         <section v-if="selectedSegment === 'channels'">
-          <ion-card v-for="channel in inventoryChannels" :key="channel.facilityGroupId">
-            <ion-card-header>
-              <div>
-                <ion-card-subtitle class="overline">{{ channel.facilityGroupId }}</ion-card-subtitle>
-                <ion-card-title>{{ channel.facilityGroupName }}</ion-card-title>
-                <ion-card-subtitle>{{ channel.description }}</ion-card-subtitle>
-              </div>
-            </ion-card-header>
-
-            <ion-item lines="full">
-              <ion-icon slot="start" :icon="globeOutline"/>
-              <ion-label>
-                {{ channel.selectedConfigFacility?.facilityName }}
-                <p>{{ channel.selectedConfigFacility?.facilityId }}</p>
-              </ion-label>
-              <ion-button slot="end" fill="clear" color="medium" @click="openLinkThresholdFacilitiesToGroupModal(channel)">
-                <ion-icon :icon="optionsOutline" slot="icon-only" />
-              </ion-button>
-            </ion-item>
-
-            <ion-list>
-              <ion-item-divider color="light">
-                <ion-label>{{ translate("Facilities") }}</ion-label>
-                <ion-button slot="end" fill="clear" color="medium" @click="openLinkFacilitiesToGroupModal(channel)">
+          <template v-if="inventoryChannels.length">
+            <ion-card v-for="channel in inventoryChannels" :key="channel.facilityGroupId">
+              <ion-card-header>
+                <div>
+                  <ion-card-subtitle class="overline">{{ channel.facilityGroupId }}</ion-card-subtitle>
+                  <ion-card-title>{{ channel.facilityGroupName }}</ion-card-title>
+                  <ion-card-subtitle>{{ channel.description }}</ion-card-subtitle>
+                </div>
+              </ion-card-header>
+  
+              <ion-item lines="full">
+                <ion-icon slot="start" :icon="globeOutline"/>
+                <ion-label>
+                  {{ channel.selectedConfigFacility?.facilityName }}
+                  <p>{{ channel.selectedConfigFacility?.facilityId }}</p>
+                </ion-label>
+                <ion-button slot="end" fill="clear" color="medium" @click="openLinkThresholdFacilitiesToGroupModal(channel)">
                   <ion-icon :icon="optionsOutline" slot="icon-only" />
                 </ion-button>
-              </ion-item-divider>
-
-              <ion-item>
-                <ion-icon slot="start" :icon="storefrontOutline"/>
-                <ion-label>{{ translate("retail facilities", { count: getFacilityCount(channel, "RETAIL_STORE") })}}</ion-label>
-              </ion-item>
-
-              <ion-item lines="full">
-                <ion-icon slot="start" :icon="businessOutline"/>
-                <ion-label>{{ translate("warehouse", { count: getFacilityCount(channel, "WAREHOUSE") })}}</ion-label>
               </ion-item>
   
-              <ion-item lines="none">
-                <ion-button fill="clear" size="default" @click="openEditGroupModal(channel)">{{ translate("Edit group") }}</ion-button>
-                <!-- Functionality is not defined for this button hence commented it for now. -->
-                <!-- <ion-button color="medium" fill="clear" slot="end">
-                  <ion-icon :icon="ellipsisVerticalOutline" slot="icon-only"/>
-                </ion-button> -->
-              </ion-item>
-            </ion-list>
-          </ion-card>
+              <ion-list>
+                <ion-item-divider color="light">
+                  <ion-label>{{ translate("Facilities") }}</ion-label>
+                  <ion-button slot="end" fill="clear" color="medium" @click="openLinkFacilitiesToGroupModal(channel)">
+                    <ion-icon :icon="optionsOutline" slot="icon-only" />
+                  </ion-button>
+                </ion-item-divider>
+  
+                <ion-item>
+                  <ion-icon slot="start" :icon="storefrontOutline"/>
+                  <ion-label>{{ translate("retail facilities", { count: getFacilityCount(channel, "RETAIL_STORE") })}}</ion-label>
+                </ion-item>
+  
+                <ion-item lines="full">
+                  <ion-icon slot="start" :icon="businessOutline"/>
+                  <ion-label>{{ translate("warehouse", { count: getFacilityCount(channel, "WAREHOUSE") })}}</ion-label>
+                </ion-item>
+    
+                <ion-item lines="none">
+                  <ion-button fill="clear" size="default" @click="openEditGroupModal(channel)">{{ translate("Edit group") }}</ion-button>
+                  <!-- Functionality is not defined for this button hence commented it for now. -->
+                  <!-- <ion-button color="medium" fill="clear" slot="end">
+                    <ion-icon :icon="ellipsisVerticalOutline" slot="icon-only"/>
+                  </ion-button> -->
+                </ion-item>
+              </ion-list>
+            </ion-card>
+          </template>
+
+          <div class="empty-state" v-else>
+            <p>{{ translate("No inventory channel found.") }}</p>
+          </div>
         </section>
  
         <section v-else-if="selectedSegment === 'publish'">


### PR DESCRIPTION
### Related Issues
 <!--  Put related issue number which this PR is closing. For example #123 -->

 Related Issue #302

 ### Short Description and Why It's Useful
 <!-- Describe in a few words what is this Pull Request changing and why it's useful -->
- Improved the api fetching logic to fetch inventory channels only for the current selected product store.
- Added empty state in case of no inventory channels found.

 ### Screenshots of Visual Changes before/after (If There Are Any)
 <!-- If you made any changes in the UI layer, please provide before/after screenshots -->
![Screenshot from 2024-05-09 11-43-46](https://github.com/hotwax/threshold-management/assets/69574321/187ce9f5-5e8b-4a32-9c13-5e6635b0b7ab)



 **IMPORTANT NOTICE** - Remember to add changelog entry


 ### Contribution and Currently Important Rules Acceptance
 <!-- Please get familiar with following info -->

 - [x] I read and followed [contribution rules](https://github.com/hotwax/threshold-management#contribution-guideline)