### PR TITLE
Fixed: ion-segment not coming in line with page title in inventory-channnels page (#305)

### DIFF
--- a/src/theme/variables.css
+++ b/src/theme/variables.css
@@ -344,6 +344,10 @@ ion-content>section {
   text-align: center; 
 }
 
+ion-toolbar > ion-segment {
+  width: unset;
+}
+
 @media (min-width: 700px) {
   main {
     max-width: 375px;

--- a/src/views/InventoryChannels.vue
+++ b/src/views/InventoryChannels.vue
@@ -3,11 +3,9 @@
     <ion-header :translucent="true">
       <ion-toolbar>
         <ion-menu-button slot="start" />
-        <ion-title>{{ translate("Inventory channels") }}</ion-title>
-      </ion-toolbar>
+        <ion-title slot="start">{{ translate("Inventory channels") }}</ion-title>
 
-      <ion-toolbar>
-        <ion-segment v-model="selectedSegment">
+        <ion-segment v-model="selectedSegment" slot="end">
           <ion-segment-button value="channels">
             <ion-label>{{ translate("Channels") }}</ion-label>
           </ion-segment-button>
@@ -219,9 +217,5 @@ ion-card-header {
   flex-direction: row;
   justify-content: space-between;
   align-items: center;
-}
-
-ion-header {
-  display: flex;
 }
 </style>

--- a/src/views/InventoryChannels.vue
+++ b/src/views/InventoryChannels.vue
@@ -219,4 +219,8 @@ ion-card-header {
   justify-content: space-between;
   align-items: center;
 }
+
+ion-header {
+  display: flex;
+}
 </style>

--- a/src/views/InventoryChannels.vue
+++ b/src/views/InventoryChannels.vue
@@ -148,6 +148,7 @@ const selectedSegment = ref("channels")
 const inventoryChannels = computed(() => store.getters["channel/getInventoryChannels"])
 
 onMounted(async() => {
+  fetchInventoryChannels()
   emitter.on("productStoreOrConfigChanged", fetchInventoryChannels);
 })
 

--- a/src/views/Shipping.vue
+++ b/src/views/Shipping.vue
@@ -4,10 +4,8 @@
       <ion-toolbar>
         <ion-menu-button slot="start" />
         <ion-title>{{ translate("Shipping") }}</ion-title>
-      </ion-toolbar>
 
-      <ion-toolbar>
-        <ion-segment v-model="selectedSegment" @ionChange="updateRuleGroup()">
+        <ion-segment v-model="selectedSegment" @ionChange="updateRuleGroup()" slot="end">
           <ion-segment-button value="RG_SHIPPING_FACILITY">
             <ion-label>{{ translate("Product and facility") }}</ion-label>
           </ion-segment-button>
@@ -157,9 +155,3 @@ function createShipping() {
   router.push({ path: '/create-shipping', query: { groupTypeEnumId: selectedSegment.value } })
 }
 </script>
-
-<style scoped>
-  ion-header {
-    display: flex;
-  }
-</style>

--- a/src/views/StorePickup.vue
+++ b/src/views/StorePickup.vue
@@ -4,10 +4,8 @@
       <ion-toolbar>
         <ion-menu-button slot="start" />
         <ion-title>{{ translate("Store pickup") }}</ion-title>
-      </ion-toolbar>
 
-      <ion-toolbar>
-        <ion-segment v-model="selectedSegment" @ionChange="updateRuleGroup()">
+        <ion-segment v-model="selectedSegment" @ionChange="updateRuleGroup()" slot="end">
           <ion-segment-button value="RG_PICKUP_FACILITY">
             <ion-label>{{ translate("Product and facility") }}</ion-label>
           </ion-segment-button>
@@ -158,9 +156,3 @@ function createStorePickup() {
   router.push({ path: '/create-store-pickup', query: { groupTypeEnumId: selectedSegment.value } })
 }
 </script>
-
-<style scoped>
-  ion-header {
-    display: flex;
-  }
-</style>


### PR DESCRIPTION
### Related Issues
 <!--  Put related issue number which this PR is closing. For example #123 -->

 Related Issue #305

 ### Short Description and Why It's Useful
 <!-- Describe in a few words what is this Pull Request changing and why it's useful -->
- Improved code to bring ion-segment in line with the header title in inventory channels page.
- Fixed inventory channels not getting fetched on page refresh.

 ### Screenshots of Visual Changes before/after (If There Are Any)
 <!-- If you made any changes in the UI layer, please provide before/after screenshots -->
Before
![Screenshot from 2024-05-10 10-30-28](https://github.com/hotwax/threshold-management/assets/69574321/778258bd-83e5-4537-bf5c-22c6be45a3df)

After
![Screenshot from 2024-05-10 10-40-22](https://github.com/hotwax/threshold-management/assets/69574321/7875fd51-666b-44d3-9414-e4eb4697811d)




 **IMPORTANT NOTICE** - Remember to add changelog entry


 ### Contribution and Currently Important Rules Acceptance
 <!-- Please get familiar with following info -->

 - [x] I read and followed [contribution rules](https://github.com/hotwax/threshold-management#contribution-guideline)