### PR TITLE
Improved: rule item card to use selectedsegment from state and logic to show group id when name not available on create rule page (#323)

### DIFF
--- a/src/components/RuleItem.vue
+++ b/src/components/RuleItem.vue
@@ -123,12 +123,13 @@ import emitter from '@/event-bus';
 const router = useRouter();
 const store = useStore();
 
-const props = defineProps(["selectedSegment", "rule", "ruleIndex"])
+const props = defineProps(["rule", "ruleIndex"])
 const total = computed(() => store.getters["rule/getTotalRulesCount"])
 const configFacilities = computed(() => store.getters["util/getConfigFacilities"])
 const facilityGroups = computed(() => store.getters["util/getFacilityGroups"])
 const rules = computed(() => store.getters["rule/getRules"]);
 const isReorderActive = computed(() => store.getters["rule/isReorderActive"]);
+const selectedSegment = computed(() => store.getters["util/getSelectedSegment"])
 
 const selectedPage = ref({
   path: '',
@@ -389,8 +390,8 @@ function editRule() {
     path = `update-shipping/${props.rule.ruleId}`
   }
 
-  if(props.selectedSegment) {
-    router.push({ path, query: { groupTypeEnumId: props.selectedSegment } });
+  if(selectedSegment.value) {
+    router.push({ path, query: { groupTypeEnumId: selectedSegment.value } });
   } else {
     router.push(path)
   }

--- a/src/views/CreateUpdateSafetyStockRule.vue
+++ b/src/views/CreateUpdateSafetyStockRule.vue
@@ -46,7 +46,7 @@
           </ion-item>
           <ion-card-content>
             <ion-chip outline v-for="group in formData.selectedFacilityGroups['included']" :key="group.facilityGroupId">
-              {{ group.facilityGroupName }}
+              {{ group.facilityGroupName ? group.facilityGroupName : group.facilityGroupId }}
               <ion-icon :icon="closeCircle" @click="removeFacilityGroups(group.facilityGroupId, 'included')" />
             </ion-chip>
           </ion-card-content>
@@ -62,7 +62,7 @@
           </ion-item>
           <ion-card-content>
             <ion-chip outline v-for="group in formData.selectedFacilityGroups['excluded']" :key="group.facilityGroupId">
-              {{ group.facilityGroupName }}
+              {{ group.facilityGroupName ? group.facilityGroupName : group.facilityGroupId }}
               <ion-icon :icon="closeCircle" @click="removeFacilityGroups(group.facilityGroupId, 'excluded')" />
             </ion-chip>
           </ion-card-content>

--- a/src/views/CreateUpdateShippingRule.vue
+++ b/src/views/CreateUpdateShippingRule.vue
@@ -48,7 +48,7 @@
             </ion-item>
             <ion-card-content>
               <ion-chip outline v-for="group in formData.selectedFacilityGroups['included']" :key="group.facilityGroupId">
-                {{ group.facilityGroupName }}
+                {{ group.facilityGroupName ? group.facilityGroupName : group.facilityGroupId }}
                 <ion-icon :icon="closeCircle" @click="removeFacilityGroups(group.facilityGroupId, 'included')" />
               </ion-chip>
             </ion-card-content>
@@ -64,7 +64,7 @@
             </ion-item>
             <ion-card-content>
               <ion-chip outline v-for="group in formData.selectedFacilityGroups['excluded']" :key="group.facilityGroupId">
-                {{ group.facilityGroupName }}
+                {{ group.facilityGroupName ? group.facilityGroupName : group.facilityGroupId }}
                 <ion-icon :icon="closeCircle" @click="removeFacilityGroups(group.facilityGroupId, 'excluded')" />
               </ion-chip>
             </ion-card-content>
@@ -80,7 +80,7 @@
           <ion-card v-for="facility in configFacilities" :key="facility.facilityId" @click="toggleFacilitySelection(facility.facilityId)" button>
             <ion-card-header>
               <div>
-                <ion-card-title>{{ facility.facilityName }}</ion-card-title>
+                <ion-card-title>{{ facility.facilityName ? facility.facilityName : facility.facilityId }}</ion-card-title>
                 <ion-card-subtitle>{{ facility.facilityId }}</ion-card-subtitle>
               </div>
               <ion-checkbox :checked="isFacilitySelected(facility.facilityId)" />


### PR DESCRIPTION
### Related Issues
 <!--  Put related issue number which this PR is closing. For example #123 -->

 Related Issue #323

 ### Short Description and Why It's Useful
 <!-- Describe in a few words what is this Pull Request changing and why it's useful -->
- Used selected segment from state on rule item component.
- Showed grouId when grouName is not present in create rule page.

 ### Screenshots of Visual Changes before/after (If There Are Any)
 <!-- If you made any changes in the UI layer, please provide before/after screenshots -->


 **IMPORTANT NOTICE** - Remember to add changelog entry


 ### Contribution and Currently Important Rules Acceptance
 <!-- Please get familiar with following info -->

 - [x] I read and followed [contribution rules](https://github.com/hotwax/threshold-management#contribution-guideline)