### PR TITLE
Improved: made channel group name mandatory in edit group modal (#325)

### DIFF
--- a/src/components/CreateGroupModal.vue
+++ b/src/components/CreateGroupModal.vue
@@ -73,7 +73,7 @@ function closeModal() {
 
 async function createGroup() {
   if (!formData.value.facilityGroupName?.trim()) {
-    showToast(translate("Please fill in all the required fields"))
+    showToast(translate("Please fill in all the required fields."))
     return;
   }
 

--- a/src/components/EditGroupModal.vue
+++ b/src/components/EditGroupModal.vue
@@ -13,7 +13,9 @@
   <ion-content>
     <ion-list>
       <ion-item>
-        <ion-input :label="translate('Name')" labelPlacement="floating" v-model="formData.facilityGroupName"/>
+        <ion-input labelPlacement="floating" v-model="formData.facilityGroupName">
+          <div slot="label">{{ translate("Name") }} <ion-text color="danger">*</ion-text></div>
+        </ion-input>
       </ion-item>
       <ion-item>
         <ion-textarea :label="translate('Description')" labelPlacement="floating" v-model="formData.description" :maxlength="255" />
@@ -29,7 +31,7 @@
 </template>
 
 <script setup lang="ts">
-import { IonButton, IonButtons, IonContent, IonFab, IonFabButton, IonHeader, IonIcon, IonInput, IonItem, IonList, IonTextarea, IonTitle, IonToolbar, modalController } from "@ionic/vue";
+import { IonButton, IonButtons, IonContent, IonFab, IonFabButton, IonHeader, IonIcon, IonInput, IonItem, IonList, IonText, IonTextarea, IonTitle, IonToolbar, modalController } from "@ionic/vue";
 import { closeOutline, saveOutline } from "ionicons/icons";
 import { translate } from "@/i18n";
 import { defineProps, onMounted, ref } from "vue";
@@ -55,6 +57,11 @@ function isGroupUpdated() {
 }
 
 async function updateGroup() {
+  if (!formData.value.facilityGroupName?.trim()) {
+    showToast(translate("Please fill in all the required fields."))
+    return;
+  }
+
   emitter.emit("presentLoader");
   try {
     const resp = await ChannelService.updateGroup({...formData.value, facilityGroupId: props.group.facilityGroupId})

--- a/src/components/OrderLimitPopover.vue
+++ b/src/components/OrderLimitPopover.vue
@@ -65,6 +65,7 @@ async function showOrderLimitAlert(header: string, message: string, showInput: b
       name: "setLimit",
       placeholder: translate("Order fulfillment capacity"),
       type: "number",
+      value: props.fulfillmentOrderLimit,
       min: 0
     }] : [],
     buttons: [{

--- a/src/views/InventoryChannels.vue
+++ b/src/views/InventoryChannels.vue
@@ -9,7 +9,8 @@
           <ion-segment-button value="channels">
             <ion-label>{{ translate("Channels") }}</ion-label>
           </ion-segment-button>
-          <ion-segment-button value="publish">
+          <!-- Todo: add functionality to the Publish segment -->
+          <ion-segment-button value="publish" disabled>
             <ion-label>{{ translate("Publish") }}</ion-label>
           </ion-segment-button>
         </ion-segment>

--- a/src/views/SafetyStock.vue
+++ b/src/views/SafetyStock.vue
@@ -67,6 +67,7 @@ onIonViewDidLeave(() => {
 
 async function fetchRules() {
   emitter.emit("presentLoader");
+  store.dispatch("rule/updateIsReorderActive", false)
   await Promise.allSettled([store.dispatch('rule/fetchRules', { groupTypeEnumId: 'RG_SAFETY_STOCK' }), store.dispatch("util/fetchConfigFacilities"), store.dispatch("util/fetchFacilityGroups")]);
   emitter.emit("dismissLoader");
 }

--- a/src/views/Shipping.vue
+++ b/src/views/Shipping.vue
@@ -109,6 +109,7 @@ async function fetchRules() {
   emitter.emit("presentLoader");
   if(!selectedSegment.value || (selectedSegment.value !== 'RG_SHIPPING_FACILITY' && selectedSegment.value !== 'RG_SHIPPING_CHANNEL' && selectedSegment.value !== 'SHIPPING_FACILITY')) store.dispatch("util/updateSelectedSegment", "RG_SHIPPING_FACILITY");
   await Promise.allSettled([store.dispatch('rule/fetchRules', { groupTypeEnumId: selectedSegment.value }), store.dispatch("util/fetchConfigFacilities"), store.dispatch("util/fetchFacilityGroups")])
+  if(selectedSegment.value === 'SHIPPING_FACILITY') fetchFacilities();
   emitter.emit("dismissLoader");
 }
 
@@ -154,7 +155,7 @@ async function updateSegment(event: any) {
   store.dispatch("util/updateSelectedSegment", event.detail.value);
 
   emitter.emit("presentLoader");
-  if(selectedSegment.value === 'facility') {
+  if(selectedSegment.value === 'SHIPPING_FACILITY') {
     isScrollingEnabled.value = false;
     await fetchFacilities();
     store.dispatch("rule/updateIsReorderActive", false)

--- a/src/views/Shipping.vue
+++ b/src/views/Shipping.vue
@@ -107,6 +107,7 @@ onIonViewDidLeave(() => {
 
 async function fetchRules() {
   emitter.emit("presentLoader");
+  store.dispatch("rule/updateIsReorderActive", false)
   if(!selectedSegment.value || (selectedSegment.value !== 'RG_SHIPPING_FACILITY' && selectedSegment.value !== 'RG_SHIPPING_CHANNEL' && selectedSegment.value !== 'SHIPPING_FACILITY')) store.dispatch("util/updateSelectedSegment", "RG_SHIPPING_FACILITY");
   await Promise.allSettled([store.dispatch('rule/fetchRules', { groupTypeEnumId: selectedSegment.value }), store.dispatch("util/fetchConfigFacilities"), store.dispatch("util/fetchFacilityGroups")])
   if(selectedSegment.value === 'SHIPPING_FACILITY') fetchFacilities();

--- a/src/views/StorePickup.vue
+++ b/src/views/StorePickup.vue
@@ -12,9 +12,11 @@
           <ion-segment-button value="RG_PICKUP_CHANNEL">
             <ion-label>{{ translate("Product and channel") }}</ion-label>
           </ion-segment-button>
-          <ion-segment-button value="PICKUP_FACILITY">
+          <!-- Hidden Facility segment for now as it is not functionality -->
+          <!-- Todo: add functionality to the Facility segment -->
+          <!-- <ion-segment-button value="PICKUP_FACILITY">
             <ion-label>{{ translate("Facility") }}</ion-label>
-          </ion-segment-button>
+          </ion-segment-button> -->
         </ion-segment>
       </ion-toolbar>
     </ion-header>

--- a/src/views/StorePickup.vue
+++ b/src/views/StorePickup.vue
@@ -110,6 +110,7 @@ onIonViewDidLeave(() => {
 
 async function fetchRules() {
   emitter.emit("presentLoader");
+  store.dispatch("rule/updateIsReorderActive", false)
   if(!selectedSegment.value || (selectedSegment.value !== 'RG_PICKUP_FACILITY' && selectedSegment.value !== 'RG_PICKUP_CHANNEL' && selectedSegment.value !== 'PICKUP_FACILITY')) store.dispatch("util/updateSelectedSegment", "RG_PICKUP_FACILITY");
   await Promise.allSettled([store.dispatch('rule/fetchRules', { groupTypeEnumId: selectedSegment.value}), store.dispatch("util/fetchConfigFacilities"), store.dispatch("util/fetchFacilityGroups")])
   emitter.emit("dismissLoader");

--- a/src/views/Threshold.vue
+++ b/src/views/Threshold.vue
@@ -67,6 +67,7 @@ onIonViewDidLeave(() => {
 
 async function fetchRules() {
   emitter.emit("presentLoader");
+  store.dispatch("rule/updateIsReorderActive", false)
   await Promise.allSettled([store.dispatch('rule/fetchRules', { groupTypeEnumId: 'RG_THRESHOLD' }), store.dispatch("util/fetchConfigFacilities"), store.dispatch("util/fetchFacilityGroups")]);
   emitter.emit("dismissLoader");
 }


### PR DESCRIPTION
### Related Issues
 <!--  Put related issue number which this PR is closing. For example #123 -->

 Related Issue #325

 ### Short Description and Why It's Useful
 <!-- Describe in a few words what is this Pull Request changing and why it's useful -->

- Made inventory channel group name mandatory while editing it in edit channel group modal.
- Disabled Publish segment and hide Facility segment since both the segments are not functional.

 ### Screenshots of Visual Changes before/after (If There Are Any)
 <!-- If you made any changes in the UI layer, please provide before/after screenshots -->


 **IMPORTANT NOTICE** - Remember to add changelog entry


 ### Contribution and Currently Important Rules Acceptance
 <!-- Please get familiar with following info -->

 - [x] I read and followed [contribution rules](https://github.com/hotwax/threshold-management#contribution-guideline)