### PR TITLE
Remove custom split pane styling

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -81,8 +81,3 @@ onUnmounted(() => {
   resetConfig()
 })
 </script>
-<style>
-  ion-split-pane {
-    --side-width: 304px;
-  }
-</style>


### PR DESCRIPTION
## Summary
- remove the custom CSS override targeting ion-split-pane so it uses the framework defaults

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_b_68f07e1ddc3c8321885d7bbf9833d650