### PR TITLE
Fixed : display of reorder button when Rule name is large (#396)

### DIFF
--- a/src/components/RuleItem.vue
+++ b/src/components/RuleItem.vue
@@ -409,6 +409,13 @@ ion-card-header {
   align-items: center;
 }
 
+ion-card-header div {
+  word-break: break-word;
+}
+ion-card-header ion-item {
+  flex: 0 0 auto;
+}
+
 .actions {
   display: flex;
   justify-content: space-between;


### PR DESCRIPTION
### Related Issues
 <!--  Put related issue number which this PR is closing. For example #123 -->

 #396

 ### Short Description and Why It's Useful
 <!-- Describe in a few words what is this Pull Request changing and why it's useful -->
- fixed display of reorder button when Rule name is large

 ### Screenshots of Visual Changes before/after (If There Are Any)
 <!-- If you made any changes in the UI layer, please provide before/after screenshots -->


 ### Contribution and Currently Important Rules Acceptance
 <!-- Please get familiar with following info -->

 - [x] I read and followed [contribution rules](https://github.com/hotwax/available-to-promise#contribution-guideline)