### PR TITLE
Enable IDE Trace Vue plugin

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "@typescript-eslint/parser": "~5.26.0",
     "@vitejs/plugin-legacy": "catalog:",
     "@vitejs/plugin-vue": "catalog:",
-    "chrome-ide-trace": "^0.1.0",
+    "chrome-ide-trace": "^0.1.1",
     "@vitejs/plugin-vue-jsx": "^5.1.5",
     "@vue/compiler-sfc": "^3.0.0-0",
     "@vue/eslint-config-typescript": "^9.1.0",

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "@ionic/core": "catalog:",
     "@ionic/vue": "catalog:",
     "@ionic/vue-router": "catalog:",
+    "ionicons": "catalog:",
     "axios": "catalog:",
     "axios-cache-adapter": "catalog:",
     "boolean-parser": "0.0.2",
@@ -50,6 +51,7 @@
     "terser": "^5.46.1",
     "typescript": "catalog:",
     "vite": "catalog:",
+    "vite-plugin-pwa": "1.2.0",
     "vitest": "catalog:"
   }
 }

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "@typescript-eslint/parser": "~5.26.0",
     "@vitejs/plugin-legacy": "catalog:",
     "@vitejs/plugin-vue": "catalog:",
+    "chrome-ide-trace": "^0.1.0",
     "@vitejs/plugin-vue-jsx": "^5.1.5",
     "@vue/compiler-sfc": "^3.0.0-0",
     "@vue/eslint-config-typescript": "^9.1.0",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "../../tsconfig.json",
+  "extends": "../accxui/tsconfig.json",
   "compilerOptions": {
     "baseUrl": ".",
     "types": [
@@ -8,8 +8,8 @@
     ],
     "paths": {
       "@/*": ["src/*"],
-      "@common": ["../../common/index.ts"],
-      "@common/*": ["../../common/*"]
+      "@common": ["../accxui/common/index.ts"],
+      "@common/*": ["../accxui/common/*"]
     }
   },
   "include": [

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -3,6 +3,7 @@ import vue from '@vitejs/plugin-vue'
 import path from 'path'
 import { defineConfig } from 'vite'
 import { versionInfoUtil } from '../../common/utils/versionInfoUtil'
+import { localMoquiDiscoveryPlugin } from '../../common/vite/localMoquiDiscoveryPlugin'
 import pkg from './package.json'
 import { VitePWA } from 'vite-plugin-pwa'
 import manifest from "./manifest.json"
@@ -20,7 +21,8 @@ export default defineConfig(({ mode }) => {
         devOptions: {
           enabled: true
         }
-      })
+      }),
+      localMoquiDiscoveryPlugin()
     ],
     define: {
       'import.meta.env.VITE_APP_VERSION_INFO': JSON.stringify(JSON.stringify(versionInfoUtil.getVersionInfo(pkg.version)))

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,5 +1,6 @@
 import legacy from '@vitejs/plugin-legacy'
 import vue from '@vitejs/plugin-vue'
+import { ideTraceVue } from 'chrome-ide-trace/vite'
 import path from 'path'
 import { defineConfig } from 'vite'
 import { versionInfoUtil } from '../accxui/common/utils/versionInfoUtil'
@@ -10,9 +11,10 @@ import manifest from "./manifest.json"
 // https://vitejs.dev/config/
 export default defineConfig(({ mode }) => {
   return {
-    plugins: [
-      vue(),
-      legacy(),
+  plugins: [
+    ideTraceVue(),
+    vue(),
+    legacy(),
       VitePWA({
         registerType: "autoUpdate", // Automatically updates the service worker, check if this correct to aut update or we should go with prompt support
         selfDestroying: true, // Unregisters any existing service worker and clears cache,

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -2,8 +2,7 @@ import legacy from '@vitejs/plugin-legacy'
 import vue from '@vitejs/plugin-vue'
 import path from 'path'
 import { defineConfig } from 'vite'
-import { versionInfoUtil } from '../../common/utils/versionInfoUtil'
-import { localMoquiDiscoveryPlugin } from '../../common/vite/localMoquiDiscoveryPlugin'
+import { versionInfoUtil } from '../accxui/common/utils/versionInfoUtil'
 import pkg from './package.json'
 import { VitePWA } from 'vite-plugin-pwa'
 import manifest from "./manifest.json"
@@ -21,8 +20,7 @@ export default defineConfig(({ mode }) => {
         devOptions: {
           enabled: true
         }
-      }),
-      localMoquiDiscoveryPlugin()
+      })
     ],
     define: {
       'import.meta.env.VITE_APP_VERSION_INFO': JSON.stringify(JSON.stringify(versionInfoUtil.getVersionInfo(pkg.version)))
@@ -30,7 +28,7 @@ export default defineConfig(({ mode }) => {
     resolve: {
       alias: {
         '@': path.resolve(__dirname, 'src'),
-        '@common': path.resolve(__dirname, '../../common')
+        '@common': path.resolve(__dirname, '../accxui/common')
       },
     },
     build: {


### PR DESCRIPTION
## Summary\n\nAdds IDE Trace plugin wiring to this app's Vite config and package config for Chrome DevTools integration from IDE Trace browser extension.\n\n## Files\n- package.json: add chrome-ide-trace devDependency\n- vite.config.{ts,js}: add ideTraceVue import and plugin entry